### PR TITLE
Bump macOS test runner to macos-12

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    runs-on: macos-10.15
+    runs-on: macos-12
     steps:
       - name: Checkout devenv repository
         uses: actions/checkout@v3


### PR DESCRIPTION
macos-10.15 is being deprecated